### PR TITLE
fix the wrong report of X and Y of mousepointer.

### DIFF
--- a/stitchcode/objects.js
+++ b/stitchcode/objects.js
@@ -2688,13 +2688,14 @@ StageMorph.prototype.initCamera = function () {
         };
 
         myself.camera.applyZoom = function () {
-            var zoom = myself.camera ? myself.camera.zoomFactor : 2,
-                width = Math.max(myself.width(), 480),
-                height = Math.max(myself.height(), 360);
-            this.left = width / - zoom;
-            this.right = width / zoom;
-            this.top = height / zoom;
-            this.bottom = height / - zoom;
+            var zoom = myself.camera ? myself.camera.zoomFactor : 2;
+            let width = Math.max(myself.width(), 480);
+            let height = Math.max(myself.height(), 360);
+            
+            this.left = width /myself.scale/ - zoom;
+            this.right = width/myself.scale / zoom;
+            this.top = height /myself.scale/ zoom;
+            this.bottom = height /myself.scale/ - zoom;
             this.updateProjectionMatrix();
         };
 


### PR DESCRIPTION
When the scale of stage is greater than 1 , if zoom the stage the report of X and Y value of the mousepointer is wrong. Now it is fixed. It also works in customized stage size. Now we can draw images by hand in app mode stage.