### PR TITLE
Actively rerender when the stage is dirty

### DIFF
--- a/stitchcode/objects.js
+++ b/stitchcode/objects.js
@@ -2637,8 +2637,19 @@ StageMorph.prototype.render = function () {
     this.renderer.render(this.scene, this.camera);
 };
 
+StageMorph.prototype.isDirty = function() {
+    var w = this.root(),
+	bounds = this.bounds;
+    
+    if (w instanceof WorldMorph) {
+	return w.broken.some(area => area.intersect(bounds).area() > 0);
+    } else {
+	return false;
+    }
+};
+
 StageMorph.prototype.renderCycle = function () {
-    if (this.renderer.changed) {
+    if (this.renderer.changed || this.isDirty()) {
         this.render();
         this.changed();
         this.parentThatIsA(IDE_Morph).statusDisplay.refresh();
@@ -2649,7 +2660,7 @@ StageMorph.prototype.renderCycle = function () {
     }
     // this.render();
     // this.changed();
-}
+};
 
 StageMorph.prototype.reRender = function () {
     this.renderer.changed = true;


### PR DESCRIPTION
Actively detect if the stage is dirty and rerender the stage. It prevents the shadows from being generated when the scripts are dragged over the stage and some unknown reasons. But your hack method is still important because the reason of  how shadows of the only sprite come from the interactive events is still unclear and the hack method does work in these situations.