### PR TITLE
Update objects.js

### DIFF
--- a/stitchcode/objects.js
+++ b/stitchcode/objects.js
@@ -1351,6 +1351,7 @@ SpriteMorph.prototype.resetAll = function () {
 	myself.isRunning = false;
 	myself.setColor(StageMorph.prototype.defaultPenColor);
 	myself.parentThatIsA(StageMorph).setPenSize(1);
+	myself.scale = 0.1;
 	myself.gotoXY(0,0);
 	myself.setHeading(90);
 	myself.clear();

--- a/stitchcode/objects.js
+++ b/stitchcode/objects.js
@@ -35,6 +35,7 @@ SpriteMorph.prototype.blockColor = {
 SpriteMorph.prototype.origInit = SpriteMorph.prototype.init;
 SpriteMorph.prototype.init = function(globals) {
     this.origInit(globals);
+    this.scale = 0.1;
     this.hide();
     this.lastJumped = false;
     this.turtle = null;
@@ -2645,7 +2646,7 @@ StageMorph.prototype.renderCycle = function () {
         this.renderer.changed = false;
 
         // this is a hack but it seems to be need for a clear render!
-        setTimeout(()=> this.changed(), 5)
+        // setTimeout(()=> this.changed(), 5)
     }
     // this.render();
     // this.changed();


### PR DESCRIPTION
Though the grey areas are automatically covered by last update there is still an anoying white area follow the sprite only in app mode and following the key event. I found it is the canvas of the sprite image. As you press the key it flashes there sometimes(not always). Make the sprite scale to 0.1 to make the canvas small and not easy to be feel. It can't be set to smaller size or the  line drawn with the move block would be biased.  Anyway very few people use keyboard to drive the sprite in  app mode(using the mouse doesn't trigger this problem). Maybe we could make it better in future versions.