### PR TITLE
Fix calculation of exty2 in turtleShepherd.js

### DIFF
--- a/stitchcode/turtleShepherd.js
+++ b/stitchcode/turtleShepherd.js
@@ -726,7 +726,7 @@ TurtleShepherd.prototype.toDST = function(name="noname") {
 	var extx1 = Math.round(this.maxX) - this.initX;
 	var exty1 = Math.round(this.maxY) - this.initY;
 	var extx2 = Math.round(this.minX) - this.initX;
-	var exty2 = Math.round(this.maxY) - this.initY;
+	var exty2 = Math.round(this.minY) - this.initY;
 	writeHeader("LA:" + name.substr(0, 16), 20, true);
 	writeHeader("ST:" + pad(this.steps, 7), 11);
 	writeHeader("CO:" + pad(this.colors.length, 3), 7);


### PR DESCRIPTION
Fix calculation of exty2 in turtleShepherd.js. I think this small glitch didn't have any influence on embroidery process for years. But it did have some influence on Hans's softare whitch is to collect student's dst files to usb sticks.